### PR TITLE
add update school registration data to the USSD menu as a further option on post initial registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 2.6
   - 2.7
 install:
-    - pip install -r requirements.pip --use-mirrors
+    - pip install -r requirements.pip --use-wheel
 before_script:
   - psql -c 'create database rts;' -U postgres
 script:

--- a/js_sandbox/lib/go-rts-zambia.js
+++ b/js_sandbox/lib/go-rts-zambia.js
@@ -477,12 +477,12 @@ function GoRtsZambia() {
                     function(choice) {
                         return choice.value;
                     },
-                    "Welcome to the Zambia School Gateway. What would you like to do?",
+                    "What would you like to do?",
                     [
                         new Choice("perf_teacher_ts_number", "Report on teacher performance."),
                         new Choice("perf_learner_boys_total", "Report on learner performance."),
                         new Choice("manage_change_emis", "Change my school."),
-                        new Choice("manage_update_school_data", " Update my school’s registration data.")
+                        new Choice("manage_update_school_data", "Update my school’s registration data.")
 
                     ]
                 );

--- a/js_sandbox/lib/go-rts-zambia.js
+++ b/js_sandbox/lib/go-rts-zambia.js
@@ -287,6 +287,10 @@ function GoRtsZambia() {
                     emis: "/api/v1/school/emis/" + parseInt(im.get_user_answer('manage_change_emis_validator')) + "/"
                 };
                 p_ht = self.cms_put("data/headteacher/" + headteacher_id + "/", headteacher_data);
+
+            } else if (im.get_user_answer('initial_state') == 'manage_update_school_data') {
+                var p = self.get_contact(im);
+                p_ht = self.cms_get("data/headteacher/?emis__emis=" + contact["extras-rts_emis"]);
             } else {
                 // create new headteacher
                 headteacher_data = self.registration_data_headteacher_collect();

--- a/js_sandbox/lib/go-rts-zambia.js
+++ b/js_sandbox/lib/go-rts-zambia.js
@@ -481,7 +481,9 @@ function GoRtsZambia() {
                     [
                         new Choice("perf_teacher_ts_number", "Report on teacher performance."),
                         new Choice("perf_learner_boys_total", "Report on learner performance."),
-                        new Choice("manage_change_emis", "Change my school.")
+                        new Choice("manage_change_emis", "Change my school."),
+                        new Choice("manage_update_school_data", " Update my school’s registration data.")
+
                     ]
                 );
             }
@@ -637,6 +639,16 @@ function GoRtsZambia() {
             new Choice("manage_change_msisdn_emis_try_2", "Try again"),
             new Choice("reg_exit_emis", "Exit")
         ]
+    ));
+    //
+    //
+    //
+    //
+
+    self.add_state(new FreeText(
+        "manage_update_school_data",
+        "manage_change_emis_validator",
+        "You'll now be asked to re-enter key school details to ensure the records are accurate. Enter 1 to continue:."
     ));
 
     self.add_state(new FreeText(

--- a/js_sandbox/lib/go-rts-zambia.js
+++ b/js_sandbox/lib/go-rts-zambia.js
@@ -640,15 +640,16 @@ function GoRtsZambia() {
             new Choice("reg_exit_emis", "Exit")
         ]
     ));
-    //
-    //
-    //
-    //
 
-    self.add_state(new FreeText(
+    self.add_state(new ChoiceState(
         "manage_update_school_data",
-        "manage_change_emis_validator",
-        "You'll now be asked to re-enter key school details to ensure the records are accurate. Enter 1 to continue:."
+        function(choice) {
+            return choice.value;
+        },
+        "You'll now be asked to re-enter key school details to ensure the records are accurate. Enter 1 to continue.",
+        [
+            new Choice("reg_school_boys", "Continue")
+        ]
     ));
 
     self.add_state(new FreeText(

--- a/js_sandbox/test/fixtures/post_registration_school_manage_update_data.json
+++ b/js_sandbox/test/fixtures/post_registration_school_manage_update_data.json
@@ -1,0 +1,52 @@
+{
+    "url": "http://qa/api/v1/data/school/",
+    "method": "POST",
+    "content_type": "application/json",
+    "data": {
+        "boys_g2": 55,
+        "classrooms": 10,
+        "created_by": "/api/v1/data/headteacher/2/",
+        "emis": "/api/v1/school/emis/1/",
+        "girls_g2": 60,
+        "name":null,
+        "teachers": 15,
+        "teachers_g1": 5,
+        "teachers_g2": 4,
+        "boys": 100,
+        "girls": 101
+    },
+    "body":  {
+        "created_at": "2013-08-14T19:57:50.232678",
+        "emis": {
+            "emis": 1,
+            "id": 2,
+            "name": "School Two",
+            "resource_uri": "/api/v1/school/2/",
+            "zone": {
+                "district": {
+                    "id": 2,
+                    "name": "District Two",
+                    "province": {
+                        "id": 2,
+                        "name": "Province Two",
+                        "resource_uri": "/api/v1/province/2/"
+                    },
+                    "resource_uri": "/api/v1/district/2/"
+                },
+                "id": 2,
+                "name": "Zone Two",
+                "resource_uri": "/api/v1/zone/2/"
+            }
+        },
+        "boys_g2": 55,
+        "classrooms": 10,
+        "girls_g2": 60,
+        "name": "School One",
+        "resource_uri": "/api/data/school/2/",
+        "teachers": 15,
+        "teachers_g1": 5,
+        "teachers_g2": 4,
+        "boys": 100,
+        "girls": 101
+    }
+}

--- a/js_sandbox/test/test-go-rts-zambia.js
+++ b/js_sandbox/test/test-go-rts-zambia.js
@@ -3213,7 +3213,7 @@ describe("When using the USSD line as an recognised MSISDN - completed Learner r
 });
 
 
-describe("When using the USSD line as a recognised MSISDN to report update the school data", function() {
+describe("When using the USSD line as a recognised MSISDN to update the school data from the manage_update_school_data state", function() {
 
     // These are used to mock API reponses
     // EXAMPLE: Response from google maps API
@@ -3286,7 +3286,7 @@ describe("When using the USSD line as a recognised MSISDN to report update the s
         p.then(done, done);
     });
 
-    it.only("saying are zonal head after association with new school should thank long and close", function (done) {
+    it("saying are zonal head after association with new school should thank long and close", function (done) {
         var user = {
             current_state: 'reg_zonal_head',
             answers: {

--- a/js_sandbox/test/test-go-rts-zambia.js
+++ b/js_sandbox/test/test-go-rts-zambia.js
@@ -3206,3 +3206,61 @@ describe("When using the USSD line as an recognised MSISDN - completed Learner r
         p.then(done, done);
     });
 });
+
+
+describe("When using the USSD line as a recognised MSISDN to report update the school data", function() {
+
+    // These are used to mock API reponses
+    // EXAMPLE: Response from google maps API
+    var fixtures = test_fixtures_full;
+    beforeEach(function() {
+        tester = new vumigo.test_utils.ImTester(app.api, {
+            custom_setup: function (api) {
+                api.config_store.config = JSON.stringify({
+                    sms_short_code: "1234",
+                    cms_api_root: 'http://qa/api/v1/'
+                });
+
+                var dummy_contact = {
+                    key: "f953710a2472447591bd59e906dc2c26",
+                    surname: "Trotter",
+                    user_account: "test-0-user",
+                    bbm_pin: null,
+                    msisdn: "+1234567",
+                    created_at: "2013-04-24 14:01:41.803693",
+                    gtalk_id: null,
+                    dob: null,
+                    groups: null,
+                    facebook_id: null,
+                    twitter_handle: null,
+                    email_address: null,
+                    name: "Rodney"
+                };
+
+                api.add_contact(dummy_contact);
+                api.update_contact_extras(dummy_contact, {
+                    "rts_id": 2,
+                    "rts_emis": 1
+                });
+
+                fixtures.forEach(function (f) {
+                    api.load_http_fixture(f);
+                });
+            },
+            async: true
+        });
+    });
+
+    it.only("it should select dsiplay choice to continue update the school registration data", function (done) {
+        var user = {
+            current_state: 'initial_state'
+        };
+        var p = tester.check_state({
+            user: user,
+            content: "4",
+            next_state: "manage_update_school_data",
+            response: "^You'll now be asked to re-enter key school details to ensure the records are accurate. Enter 1 to continue:\\.$"
+        });
+        p.then(done, done);
+    });
+});

--- a/js_sandbox/test/test-go-rts-zambia.js
+++ b/js_sandbox/test/test-go-rts-zambia.js
@@ -1170,10 +1170,11 @@ describe("When using the USSD line as an recognised MSISDN to report on teachers
             user: null,
             content: null,
             next_state: "initial_state",
-            response: "^Welcome to the Zambia School Gateway. What would you like to do\\?[^]" +
+            response: "^What would you like to do\\?[^]" +
                     "1. Report on teacher performance\\.[^]" +
                     "2. Report on learner performance\\.[^]" +
-                    "3. Change my school\\.$"
+                    "3. Change my school\\.[^]" +
+                    "4. Update my school’s registration data\\.$"
         });
         p.then(done, done);
     });
@@ -2083,10 +2084,11 @@ describe("When using the USSD line as an recognised MSISDN - completed Teacher r
             user: user,
             content: "2",
             next_state: "initial_state",
-            response: "^Welcome to the Zambia School Gateway. What would you like to do\\?[^]" +
+            response: "^What would you like to do\\?[^]" +
                     "1. Report on teacher performance\\.[^]" +
                     "2. Report on learner performance\\.[^]" +
-                    "3. Change my school\\.$"
+                    "3. Change my school\\.[^]" +
+                    "4. Update my school’s registration data\\.$"
         });
         p.then(done, done);
     });
@@ -2174,10 +2176,11 @@ describe("When using the USSD line as an recognised MSISDN to report on learners
             user: null,
             content: null,
             next_state: "initial_state",
-            response: "^Welcome to the Zambia School Gateway. What would you like to do\\?[^]" +
+            response: "^What would you like to do\\?[^]" +
                     "1. Report on teacher performance\\.[^]" +
                     "2. Report on learner performance\\.[^]" +
-                    "3. Change my school\\.$"
+                    "3. Change my school\\.[^]" +
+                    "4. Update my school’s registration data\\.$"
         });
         p.then(done, done);
     });
@@ -3163,10 +3166,11 @@ describe("When using the USSD line as an recognised MSISDN - completed Learner r
             user: user,
             content: "1",
             next_state: "initial_state",
-            response: "^Welcome to the Zambia School Gateway. What would you like to do\\?[^]" +
+            response: "^What would you like to do\\?[^]" +
                     "1. Report on teacher performance\\.[^]" +
                     "2. Report on learner performance\\.[^]" +
-                    "3. Change my school\\.$"
+                    "3. Change my school\\.[^]" +
+                    "4. Update my school’s registration data\\.$"
         });
         p.then(done, done);
     });
@@ -3251,7 +3255,7 @@ describe("When using the USSD line as a recognised MSISDN to report update the s
         });
     });
 
-    it.only("it should select display choice to continue update the school registration data", function (done) {
+    it("it should select display choice to continue update the school registration data", function (done) {
         var user = {
             current_state: 'initial_state'
         };
@@ -3265,7 +3269,7 @@ describe("When using the USSD line as a recognised MSISDN to report update the s
         p.then(done, done);
     });
 
-    it("on continue pressed should reirect to reg_school_boys", function (done) {
+    it("on continue pressed should redirect to reg_school_boys state", function (done) {
         var user = {
             current_state: 'manage_update_school_data',
             answers: {

--- a/js_sandbox/test/test-go-rts-zambia.js
+++ b/js_sandbox/test/test-go-rts-zambia.js
@@ -25,6 +25,7 @@ var test_fixtures_full = [
     'test/fixtures/post_registration_headteacher_zonal.json',
     'test/fixtures/post_registration_school.json',
     'test/fixtures/post_registration_school_update.json',
+    'test/fixtures/post_registration_school_manage_update_data.json',
     'test/fixtures/post_performance_teacher.json',
     'test/fixtures/post_performance_learner_boys.json',
     'test/fixtures/post_performance_learner_girls.json',
@@ -3281,6 +3282,35 @@ describe("When using the USSD line as a recognised MSISDN to report update the s
             content: "1",
             next_state: "reg_school_boys",
             response: "^How many boys do you have in your school\\?$"
+        });
+        p.then(done, done);
+    });
+
+    it.only("saying are zonal head after association with new school should thank long and close", function (done) {
+        var user = {
+            current_state: 'reg_zonal_head',
+            answers: {
+                initial_state: 'manage_update_school_data',
+                reg_school_boys: '100',
+                reg_school_girls: '101',
+                reg_school_classrooms: '10',
+                reg_school_teachers: '15',
+                reg_school_teachers_g1: '5',
+                reg_school_teachers_g2: '4',
+                reg_school_students_g2_boys: '55',
+                reg_school_students_g2_girls: '60'
+
+            }
+        };
+        var p = tester.check_state({
+            user: user,
+            content: "1",
+            next_state: "reg_thanks_zonal_head",
+            response: "^Well done! You are now registered as a Zonal Head" +
+                " Teacher\\. When you are ready, dial in to start" +
+                " reporting\\. You will also receive monthly SMS's from" +
+                " your zone\\.$",
+            continue_session: false
         });
         p.then(done, done);
     });

--- a/js_sandbox/test/test-go-rts-zambia.js
+++ b/js_sandbox/test/test-go-rts-zambia.js
@@ -3251,7 +3251,7 @@ describe("When using the USSD line as a recognised MSISDN to report update the s
         });
     });
 
-    it.only("it should select dsiplay choice to continue update the school registration data", function (done) {
+    it.only("it should select display choice to continue update the school registration data", function (done) {
         var user = {
             current_state: 'initial_state'
         };
@@ -3259,7 +3259,24 @@ describe("When using the USSD line as a recognised MSISDN to report update the s
             user: user,
             content: "4",
             next_state: "manage_update_school_data",
-            response: "^You'll now be asked to re-enter key school details to ensure the records are accurate. Enter 1 to continue:\\.$"
+            response: "^You'll now be asked to re-enter key school details to " +
+                        "ensure the records are accurate. Enter 1 to continue."
+        });
+        p.then(done, done);
+    });
+
+    it("on continue pressed should reirect to reg_school_boys", function (done) {
+        var user = {
+            current_state: 'manage_update_school_data',
+            answers: {
+                initial_state: 'manage_update_school_data'
+            }
+        };
+        var p = tester.check_state({
+            user: user,
+            content: "1",
+            next_state: "reg_school_boys",
+            response: "^How many boys do you have in your school\\?$"
         });
         p.then(done, done);
     });


### PR DESCRIPTION
This is for recognised MSISDN's only. Updated menu should now be (Note changed intro too.):

> What would you like to do? 
> 1. Report on teacher performance 
> 2. Report on learner performance 
> 3. Change my school 
> 4. Update my school’s registration data

Selecting 4 should drop into a new choice state `manage_update_school_data`. Text:

> You'll now be asked to re-enter key school details to ensure the records are accurate. Enter 1 to continue:
> 1. Continue

Selected 1 should drop into the new `reg_school_boys` state. The self.cms_registration function will need updating to look at initial_state to see what the user was trying to do.
