### PR TITLE
Extended JS metrics

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -2473,7 +2473,7 @@ go.app = function() {
         var $ = self.$;
 
         self.init = function() {
-
+            self.im.setMaxListeners(11);  // increase listener limit
             // Use the metrics helper to add the required metrics
             mh = new MetricsHelper(self.im);
             mh
@@ -2580,6 +2580,30 @@ go.app = function() {
                         state: 'reg_district_official_thanks'
                     }, {
                         sessions_between_states: 'avg.sessions_reg_district_admin'
+                    })
+
+                // Average sessions to complete learner performance reports
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'perf_learner_boys_total'
+                    }, {
+                        action: 'enter',
+                        state: 'perf_learner_completed'
+                    }, {
+                        sessions_between_states: 'avg.sessions_perf_learner_report'
+                    })
+
+                // Average sessions to complete teacher performance reports
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'perf_teacher_ts_number'
+                    }, {
+                        action: 'enter',
+                        state: 'perf_teacher_completed'
+                    }, {
+                        sessions_between_states: 'avg.sessions_perf_teacher_report'
                     })
 
             ;

--- a/go-app.js
+++ b/go-app.js
@@ -2437,7 +2437,6 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
-            self.im.setMaxListeners(15);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users

--- a/go-app.js
+++ b/go-app.js
@@ -2473,7 +2473,7 @@ go.app = function() {
         var $ = self.$;
 
         self.init = function() {
-            self.im.setMaxListeners(11);  // increase listener limit
+            self.im.setMaxListeners(15);  // increase listener limit
             // Use the metrics helper to add the required metrics
             mh = new MetricsHelper(self.im);
             mh
@@ -2604,6 +2604,30 @@ go.app = function() {
                         state: 'perf_teacher_completed'
                     }, {
                         sessions_between_states: 'avg.sessions_perf_teacher_report'
+                    })
+
+                // Average sessions to complete school monitoring report - school falling behind
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'monitor_school_see_lpip'
+                    }, {
+                        action: 'enter',
+                        state: 'monitor_school_falling_behind'
+                    }, {
+                        sessions_between_states: 'avg.sessions_school_monitoring_behind'
+                    })
+
+                // Average sessions to complete school monitoring report - complete lpip
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'monitor_school_see_lpip'
+                    }, {
+                        action: 'enter',
+                        state: 'monitor_school_completed'
+                    }, {
+                        sessions_between_states: 'avg.sessions_school_monitoring_complete'
                     })
 
             ;

--- a/go-app.js
+++ b/go-app.js
@@ -2437,7 +2437,7 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
-            self.im.setMaxListeners(11);  // increase listener limit
+            self.im.setMaxListeners(13);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users
@@ -2489,7 +2489,25 @@ go.app = function() {
                         },
                         'sum.learner_performance_reports.ussd'
                     )
+                    // The above metric is duplicated to align with the django
+                    // code, where girls = 1 report, boys = 1 report - 2 total
+                    .add.total_state_actions(
+                        {
+                            state: 'perf_learner_girls_writing',
+                            action: 'exit'
+                        },
+                        'sum.learner_performance_reports.ussd'
+                    )
                     // Total learner performance reports added (USSD + Django)
+                    .add.total_state_actions(
+                        {
+                            state: 'perf_learner_girls_writing',
+                            action: 'exit'
+                        },
+                        'sum.learner_performance_reports.total'
+                    )
+                    // The above metric is duplicated to align with the django
+                    // code, where girls = 1 report, boys = 1 report - 2 total
                     .add.total_state_actions(
                         {
                             state: 'perf_learner_girls_writing',

--- a/go-app.js
+++ b/go-app.js
@@ -2463,22 +2463,6 @@ go.app = function() {
                         },
                         'sum.head_teacher_registrations.ussd'
                     )
-                    // Total head teachers added (USSD + Django) - zonal heads
-                    .add.total_state_actions(
-                        {
-                            state: 'reg_zonal_head',
-                            action: 'exit'
-                        },
-                        'sum.head_teacher_registrations.total'
-                    )
-                    // Total head teachers added (USSD + Django) - non zonal heads
-                    .add.total_state_actions(
-                        {
-                            state: 'reg_zonal_head_name',
-                            action: 'exit'
-                        },
-                        'sum.head_teacher_registrations.total'
-                    )
 
                 // Learner performance reports
                     // Total learner performance reports added via USSD
@@ -2498,23 +2482,6 @@ go.app = function() {
                         },
                         'sum.learner_performance_reports.ussd'
                     )
-                    // Total learner performance reports added (USSD + Django)
-                    .add.total_state_actions(
-                        {
-                            state: 'perf_learner_girls_writing',
-                            action: 'exit'
-                        },
-                        'sum.learner_performance_reports.total'
-                    )
-                    // The above metric is duplicated to align with the django
-                    // code, where girls = 1 report, boys = 1 report - 2 total
-                    .add.total_state_actions(
-                        {
-                            state: 'perf_learner_girls_writing',
-                            action: 'exit'
-                        },
-                        'sum.learner_performance_reports.total'
-                    )
 
                 // Teacher performance reports
                     // Total teacher performance reports added via USSD
@@ -2524,14 +2491,6 @@ go.app = function() {
                             action: 'exit'
                         },
                         'sum.teacher_performance_reports.ussd'
-                    )
-                    // Total teacher performance reports added (USSD + Django)
-                    .add.total_state_actions(
-                        {
-                            state: 'perf_teacher_reading_total',
-                            action: 'exit'
-                        },
-                        'sum.teacher_performance_reports.total'
                     )
 
                 // School monitoring reports
@@ -2550,22 +2509,6 @@ go.app = function() {
                             action: 'enter'
                         },
                         'sum.school_monitoring_reports.ussd'
-                    )
-                    // Total school monitoring reports added (USSD + Django) - good lpip
-                    .add.total_state_actions(
-                        {
-                            state: 'monitor_school_talking_wall',
-                            action: 'exit'
-                        },
-                        'sum.school_monitoring_reports.total'
-                    )
-                    // Total school monitoring reports added (USSD + Django) - poor lpip
-                    .add.total_state_actions(
-                        {
-                            state: 'monitor_school_falling_behind',
-                            action: 'enter'
-                        },
-                        'sum.school_monitoring_reports.total'
                     )
 
                 // Average sessions to register

--- a/go-app.js
+++ b/go-app.js
@@ -2437,6 +2437,7 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
+            self.im.setMaxListeners(11);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users
@@ -2515,39 +2516,39 @@ go.app = function() {
                         'sum.teacher_performance_reports.total'
                     )
 
-                // // School monitoring reports
-                //     // Total school monitoring reports added via USSD - good lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_talking_wall',
-                //             action: 'exit'
-                //         },
-                //         'sum.school_monitoring_reports.ussd'
-                //     )
-                //     // Total school monitoring reports added via USSD - poor lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_falling_behind',
-                //             action: 'enter'
-                //         },
-                //         'sum.school_monitoring_reports.ussd'
-                //     )
-                //     // Total school monitoring reports added (USSD + Django) - good lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_talking_wall',
-                //             action: 'exit'
-                //         },
-                //         'sum.school_monitoring_reports.total'
-                //     )
-                //     // Total school monitoring reports added (USSD + Django) - poor lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_falling_behind',
-                //             action: 'enter'
-                //         },
-                //         'sum.school_monitoring_reports.total'
-                //     )
+                // School monitoring reports
+                    // Total school monitoring reports added via USSD - good lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_talking_wall',
+                            action: 'exit'
+                        },
+                        'sum.school_monitoring_reports.ussd'
+                    )
+                    // Total school monitoring reports added via USSD - poor lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_falling_behind',
+                            action: 'enter'
+                        },
+                        'sum.school_monitoring_reports.ussd'
+                    )
+                    // Total school monitoring reports added (USSD + Django) - good lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_talking_wall',
+                            action: 'exit'
+                        },
+                        'sum.school_monitoring_reports.total'
+                    )
+                    // Total school monitoring reports added (USSD + Django) - poor lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_falling_behind',
+                            action: 'enter'
+                        },
+                        'sum.school_monitoring_reports.total'
+                    )
 
             ;
 

--- a/go-app.js
+++ b/go-app.js
@@ -2437,7 +2437,7 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
-            self.im.setMaxListeners(13);  // increase listener limit
+            self.im.setMaxListeners(15);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users
@@ -2567,6 +2567,40 @@ go.app = function() {
                         },
                         'sum.school_monitoring_reports.total'
                     )
+
+                // Average sessions to register
+                    // Head teacher (if they register as zonal head)
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'reg_emis'
+                    }, {
+                        action: 'enter',
+                        state: 'reg_thanks_zonal_head'
+                    }, {
+                        sessions_between_states: 'avg.sessions_reg_ht_zonal_head'
+                    })
+
+                    // Head teacher (if they are NOT a zonal head)
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'reg_emis'
+                    }, {
+                        action: 'enter',
+                        state: 'reg_thanks_head_teacher'
+                    }, {
+                        sessions_between_states: 'avg.sessions_reg_headteacher'
+                    })
+
+                    // District official
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'reg_district_official'
+                    }, {
+                        action: 'enter',
+                        state: 'reg_district_official_thanks'
+                    }, {
+                        sessions_between_states: 'avg.sessions_reg_district_admin'
+                    })
 
             ;
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "q": "~0.9",
     "lodash": "~2.4.1",
     "moment": "~2.5.1",
-    "go-jsbox-metrics-helper": "~0.1.0"
+    "go-jsbox-metrics-helper": "~0.1.1"
   },
   "devDependencies": {
     "mocha": "~1.18",

--- a/src/app.js
+++ b/src/app.js
@@ -357,7 +357,7 @@ go.app = function() {
         var $ = self.$;
 
         self.init = function() {
-            self.im.setMaxListeners(11);  // increase listener limit
+            self.im.setMaxListeners(15);  // increase listener limit
             // Use the metrics helper to add the required metrics
             mh = new MetricsHelper(self.im);
             mh
@@ -488,6 +488,30 @@ go.app = function() {
                         state: 'perf_teacher_completed'
                     }, {
                         sessions_between_states: 'avg.sessions_perf_teacher_report'
+                    })
+
+                // Average sessions to complete school monitoring report - school falling behind
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'monitor_school_see_lpip'
+                    }, {
+                        action: 'enter',
+                        state: 'monitor_school_falling_behind'
+                    }, {
+                        sessions_between_states: 'avg.sessions_school_monitoring_behind'
+                    })
+
+                // Average sessions to complete school monitoring report - complete lpip
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'monitor_school_see_lpip'
+                    }, {
+                        action: 'enter',
+                        state: 'monitor_school_completed'
+                    }, {
+                        sessions_between_states: 'avg.sessions_school_monitoring_complete'
                     })
 
             ;

--- a/src/app.js
+++ b/src/app.js
@@ -321,7 +321,7 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
-            self.im.setMaxListeners(11);  // increase listener limit
+            self.im.setMaxListeners(13);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users
@@ -373,7 +373,25 @@ go.app = function() {
                         },
                         'sum.learner_performance_reports.ussd'
                     )
+                    // The above metric is duplicated to align with the django
+                    // code, where girls = 1 report, boys = 1 report - 2 total
+                    .add.total_state_actions(
+                        {
+                            state: 'perf_learner_girls_writing',
+                            action: 'exit'
+                        },
+                        'sum.learner_performance_reports.ussd'
+                    )
                     // Total learner performance reports added (USSD + Django)
+                    .add.total_state_actions(
+                        {
+                            state: 'perf_learner_girls_writing',
+                            action: 'exit'
+                        },
+                        'sum.learner_performance_reports.total'
+                    )
+                    // The above metric is duplicated to align with the django
+                    // code, where girls = 1 report, boys = 1 report - 2 total
                     .add.total_state_actions(
                         {
                             state: 'perf_learner_girls_writing',

--- a/src/app.js
+++ b/src/app.js
@@ -321,7 +321,7 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
-            self.im.setMaxListeners(13);  // increase listener limit
+            self.im.setMaxListeners(15);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users
@@ -451,6 +451,40 @@ go.app = function() {
                         },
                         'sum.school_monitoring_reports.total'
                     )
+
+                // Average sessions to register
+                    // Head teacher (if they register as zonal head)
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'reg_emis'
+                    }, {
+                        action: 'enter',
+                        state: 'reg_thanks_zonal_head'
+                    }, {
+                        sessions_between_states: 'avg.sessions_reg_ht_zonal_head'
+                    })
+
+                    // Head teacher (if they are NOT a zonal head)
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'reg_emis'
+                    }, {
+                        action: 'enter',
+                        state: 'reg_thanks_head_teacher'
+                    }, {
+                        sessions_between_states: 'avg.sessions_reg_headteacher'
+                    })
+
+                    // District official
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'reg_district_official'
+                    }, {
+                        action: 'enter',
+                        state: 'reg_district_official_thanks'
+                    }, {
+                        sessions_between_states: 'avg.sessions_reg_district_admin'
+                    })
 
             ;
 

--- a/src/app.js
+++ b/src/app.js
@@ -347,22 +347,6 @@ go.app = function() {
                         },
                         'sum.head_teacher_registrations.ussd'
                     )
-                    // Total head teachers added (USSD + Django) - zonal heads
-                    .add.total_state_actions(
-                        {
-                            state: 'reg_zonal_head',
-                            action: 'exit'
-                        },
-                        'sum.head_teacher_registrations.total'
-                    )
-                    // Total head teachers added (USSD + Django) - non zonal heads
-                    .add.total_state_actions(
-                        {
-                            state: 'reg_zonal_head_name',
-                            action: 'exit'
-                        },
-                        'sum.head_teacher_registrations.total'
-                    )
 
                 // Learner performance reports
                     // Total learner performance reports added via USSD
@@ -382,23 +366,6 @@ go.app = function() {
                         },
                         'sum.learner_performance_reports.ussd'
                     )
-                    // Total learner performance reports added (USSD + Django)
-                    .add.total_state_actions(
-                        {
-                            state: 'perf_learner_girls_writing',
-                            action: 'exit'
-                        },
-                        'sum.learner_performance_reports.total'
-                    )
-                    // The above metric is duplicated to align with the django
-                    // code, where girls = 1 report, boys = 1 report - 2 total
-                    .add.total_state_actions(
-                        {
-                            state: 'perf_learner_girls_writing',
-                            action: 'exit'
-                        },
-                        'sum.learner_performance_reports.total'
-                    )
 
                 // Teacher performance reports
                     // Total teacher performance reports added via USSD
@@ -408,14 +375,6 @@ go.app = function() {
                             action: 'exit'
                         },
                         'sum.teacher_performance_reports.ussd'
-                    )
-                    // Total teacher performance reports added (USSD + Django)
-                    .add.total_state_actions(
-                        {
-                            state: 'perf_teacher_reading_total',
-                            action: 'exit'
-                        },
-                        'sum.teacher_performance_reports.total'
                     )
 
                 // School monitoring reports
@@ -434,22 +393,6 @@ go.app = function() {
                             action: 'enter'
                         },
                         'sum.school_monitoring_reports.ussd'
-                    )
-                    // Total school monitoring reports added (USSD + Django) - good lpip
-                    .add.total_state_actions(
-                        {
-                            state: 'monitor_school_talking_wall',
-                            action: 'exit'
-                        },
-                        'sum.school_monitoring_reports.total'
-                    )
-                    // Total school monitoring reports added (USSD + Django) - poor lpip
-                    .add.total_state_actions(
-                        {
-                            state: 'monitor_school_falling_behind',
-                            action: 'enter'
-                        },
-                        'sum.school_monitoring_reports.total'
                     )
 
                 // Average sessions to register

--- a/src/app.js
+++ b/src/app.js
@@ -321,6 +321,7 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
+            self.im.setMaxListeners(11);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users
@@ -399,39 +400,39 @@ go.app = function() {
                         'sum.teacher_performance_reports.total'
                     )
 
-                // // School monitoring reports
-                //     // Total school monitoring reports added via USSD - good lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_talking_wall',
-                //             action: 'exit'
-                //         },
-                //         'sum.school_monitoring_reports.ussd'
-                //     )
-                //     // Total school monitoring reports added via USSD - poor lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_falling_behind',
-                //             action: 'enter'
-                //         },
-                //         'sum.school_monitoring_reports.ussd'
-                //     )
-                //     // Total school monitoring reports added (USSD + Django) - good lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_talking_wall',
-                //             action: 'exit'
-                //         },
-                //         'sum.school_monitoring_reports.total'
-                //     )
-                //     // Total school monitoring reports added (USSD + Django) - poor lpip
-                //     .add.total_state_actions(
-                //         {
-                //             state: 'monitor_school_falling_behind',
-                //             action: 'enter'
-                //         },
-                //         'sum.school_monitoring_reports.total'
-                //     )
+                // School monitoring reports
+                    // Total school monitoring reports added via USSD - good lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_talking_wall',
+                            action: 'exit'
+                        },
+                        'sum.school_monitoring_reports.ussd'
+                    )
+                    // Total school monitoring reports added via USSD - poor lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_falling_behind',
+                            action: 'enter'
+                        },
+                        'sum.school_monitoring_reports.ussd'
+                    )
+                    // Total school monitoring reports added (USSD + Django) - good lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_talking_wall',
+                            action: 'exit'
+                        },
+                        'sum.school_monitoring_reports.total'
+                    )
+                    // Total school monitoring reports added (USSD + Django) - poor lpip
+                    .add.total_state_actions(
+                        {
+                            state: 'monitor_school_falling_behind',
+                            action: 'enter'
+                        },
+                        'sum.school_monitoring_reports.total'
+                    )
 
             ;
 

--- a/src/app.js
+++ b/src/app.js
@@ -357,7 +357,7 @@ go.app = function() {
         var $ = self.$;
 
         self.init = function() {
-
+            self.im.setMaxListeners(11);  // increase listener limit
             // Use the metrics helper to add the required metrics
             mh = new MetricsHelper(self.im);
             mh
@@ -464,6 +464,30 @@ go.app = function() {
                         state: 'reg_district_official_thanks'
                     }, {
                         sessions_between_states: 'avg.sessions_reg_district_admin'
+                    })
+
+                // Average sessions to complete learner performance reports
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'perf_learner_boys_total'
+                    }, {
+                        action: 'enter',
+                        state: 'perf_learner_completed'
+                    }, {
+                        sessions_between_states: 'avg.sessions_perf_learner_report'
+                    })
+
+                // Average sessions to complete teacher performance reports
+                    // Does not include adding EMIS for District Admins
+                    .add.tracker({
+                        action: 'enter',
+                        state: 'perf_teacher_ts_number'
+                    }, {
+                        action: 'enter',
+                        state: 'perf_teacher_completed'
+                    }, {
+                        sessions_between_states: 'avg.sessions_perf_teacher_report'
                     })
 
             ;

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 var vumigo = require('vumigo_v02');
 var moment = require('moment');
 var _ = require('lodash');
+var Q = require('q');
 var MetricsHelper = require('go-jsbox-metrics-helper');
 var ChoiceState = vumigo.states.ChoiceState;
 var EndState = vumigo.states.EndState;
@@ -304,6 +305,43 @@ go.utils = {
         data.emis = "/api/v1/school/emis/" + emis + "/";
 
         return data;
+    },
+
+    get_province: function(im, contact) {
+        path = "school?emis=" + contact.extra.rts_emis;
+        return go.utils
+            .cms_get(path, im)
+            .then(function(result) {
+                var contact_province = result.data.objects[0].zone.district.province.name;
+                return contact_province;
+            });
+    },
+
+    fire_province_metrics: function(im, contact) {
+        // if contact has no emis we cannot tell which province they're from
+        if (_.isUndefined(contact.extra.rts_emis)) {
+            return Q();
+
+        // else if province is saved against contact use contact extra
+        } else if (!_.isUndefined(contact.extra.province)) {
+            var contact_province = contact.extra.province;
+            // strip spaces from province name for metric
+            contact_province = contact_province.replace(/\s/g,'');
+            return im.metrics.fire.inc(['sum', 'sessions', contact_province].join('.'), 1);
+
+        // else look up the province, use that, and save province against their contact for future
+        } else {
+            return go.utils
+                .get_province(im, contact)
+                .then(function(contact_province) {
+                    contact.extra.province = contact_province;
+                    contact_province = contact_province.replace(/\s/g,'');
+                    return Q.all([
+                        im.contacts.save(contact),
+                        im.metrics.fire.inc(['sum', 'sessions', contact_province].join('.'), 1)
+                    ]);
+                });
+        }
     }
 
 };
@@ -433,6 +471,11 @@ go.app = function() {
             // Navigation tracking to measure drop-offs
             self.im.on('state:exit', function(e) {
                 return self.im.metrics.fire.inc(['sum', e.state.name, 'exits'].join('.'), 1);
+            });
+
+            // Measure sessions per province
+            self.im.on('session:new', function(e) {
+                return go.utils.fire_province_metrics(self.im, self.contact);
             });
 
             self.env = self.im.config.env;

--- a/src/app.js
+++ b/src/app.js
@@ -321,7 +321,6 @@ go.app = function() {
         self.init = function() {
 
             // Use the metrics helper to add the required metrics
-            self.im.setMaxListeners(15);  // increase listener limit
             mh = new MetricsHelper(self.im);
             mh
                 // Total unique users

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5092,7 +5092,7 @@ describe("when a registered user logs on", function() {
 // METRICS
 // -------
 
-describe.only("test metric firing in various places", function() {
+describe("test metric firing in various places", function() {
 
     describe("when a registered user logs on", function() {
         it("should increase the number of sessions metrics", function() {
@@ -5145,7 +5145,6 @@ describe.only("test metric firing in various places", function() {
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['sum.head_teacher_registrations.ussd'].values, [1]);
-                    assert.deepEqual(metrics['sum.head_teacher_registrations.total'].values, [1]);
                 })
                 .run();
         });
@@ -5266,7 +5265,6 @@ describe.only("test metric firing in various places", function() {
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['sum.learner_performance_reports.ussd'].values, [1, 2]);
-                    assert.deepEqual(metrics['sum.learner_performance_reports.total'].values, [1, 2]);
                 })
                 .run();
         });
@@ -5300,7 +5298,6 @@ describe.only("test metric firing in various places", function() {
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['sum.teacher_performance_reports.ussd'].values, [1]);
-                    assert.deepEqual(metrics['sum.teacher_performance_reports.total'].values, [1]);
                 })
                 .run();
         });
@@ -5334,7 +5331,6 @@ describe.only("test metric firing in various places", function() {
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['sum.school_monitoring_reports.ussd'].values, [1]);
-                    assert.deepEqual(metrics['sum.school_monitoring_reports.total'].values, [1]);
                 })
                 .run();
         });
@@ -5354,7 +5350,6 @@ describe.only("test metric firing in various places", function() {
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['sum.school_monitoring_reports.ussd'].values, [1]);
-                    assert.deepEqual(metrics['sum.school_monitoring_reports.total'].values, [1]);
                 })
                 .run();
         });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5406,6 +5406,61 @@ describe("test metric firing in various places", function() {
         });
     });
 
+    describe("when the user completes a school monitoring report - school behind", function() {
+        it("should fire average sessions to complete metric", function() {
+            return tester
+                .setup.user.addr('097555')  // zonal head
+                .inputs(
+                    'start',
+                    '3',  // initial_state_zonal_head
+                    '4342',  // add_emis_school_monitoring
+                    '1',  // monitor_school_visit_complete
+                    '3',  // monitor_school_see_lpip
+                    '3',  // monitor_school_g2_observation_results
+                    '3',  // monitor_school_gala_sheets
+                    '1'  // monitor_school_falling_behind
+                )
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_school_monitoring_behind'].values, [1]);
+                })
+                .run();
+        });
+    });
+
+    describe("when the user completes a school monitoring report - complete", function() {
+        it("should fire average sessions to complete metric", function() {
+            return tester
+                .setup.user.addr('097555')  // zonal head
+                .inputs(
+                    'start',
+                    '3',  // initial_state_zonal_head
+                    '4342',  // add_emis_school_monitoring
+                    '1',  // monitor_school_visit_complete
+                    '1',  // monitor_school_see_lpip
+                    '3',  // monitor_school_teaching q01
+                    '2',  // monitor_school_learner_assessment q02
+                    '1',  // monitor_school_learning_materials q03
+                    '3',  // monitor_school_learner_attendance q04
+                    '2',  // monitor_school_reading_time q05
+                    '1',  // monitor_school_struggling_learners q06
+                    '2',  // monitor_school_g2_observation_results q07
+                    '1',  // monitor_school_ht_feedback q08
+                    '2',  // monitor_school_submitted_classroom q09
+                    '1',  // monitor_school_gala_sheets q10
+                    '2',  // monitor_school_summary_worksheet q11
+                    '1',  // monitor_school_ht_feedback_literacy q12
+                    '3',  // monitor_school_submitted_gala q13
+                    '2'  // monitor_school_talking_wall q14
+                )
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_school_monitoring_complete'].values, [1]);
+                })
+                .run();
+        });
+    });
+
     describe("when a district official finishes reporting on learner performance", function() {
         it("should fire total learner performance reports metrics", function() {
             return tester

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5222,7 +5222,7 @@ describe("test metric firing in various places", function() {
     });
 
     describe("when a district official finishes reporting on school monitoring", function() {
-        it.skip("should fire total school monitoring reports metrics for complete lpip", function() {
+        it("should fire total school monitoring reports metrics for complete lpip", function() {
             return tester
                 .setup.user.addr('097555')  // zonal head
                 .inputs(
@@ -5254,7 +5254,7 @@ describe("test metric firing in various places", function() {
                 .run();
         });
 
-        it.skip("should fire total school monitoring reports metrics for incomplete lpip", function() {
+        it("should fire total school monitoring reports metrics for incomplete lpip", function() {
             return tester
                 .setup.user.addr('097555')  // zonal head
                 .inputs(

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -2948,7 +2948,7 @@ describe("when a registered user logs on", function() {
                 });
 
                 describe("if the number validates (equals)", function() {
-                    it.only("should ask for boys below minimum results", function() {
+                    it("should ask for boys below minimum results", function() {
                         return tester
                             .setup.user.addr('097555')
                             .inputs(
@@ -5307,6 +5307,100 @@ describe("test metric firing in various places", function() {
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['avg.sessions_reg_district_admin'].values, [3]);
+                })
+                .run();
+        });
+    });
+
+    describe("when the user completes a learner performance report", function() {
+        it("should fire average sessions to complete metric", function() {
+            return tester
+                .setup.user.addr('097555')
+                .inputs(
+                    {session_event: 'new'},
+                    '2',  // initial_state_head_teacher
+                    '52', // perf_learner_boys_total
+                    '10',  // perf_learner_boys_outstanding
+                    {session_event: 'new'},
+                    '15',  // perf_learner_boys_desirable
+                    '20',  // perf_learner_boys_minimum
+                    '7',  // perf_learner_boys_below_minimum
+                    '49',  // perf_learner_girls_total
+                    '10',  // perf_learner_girls_outstanding
+                    {session_event: 'new'},
+                    '15',  // perf_learner_girls_desirable
+                    '20',  // perf_learner_girls_minimum
+                    '4',  // perf_learner_girls_below_minimum
+                    '31',  // perf_learner_boys_phonics
+                    '32',  // perf_learner_girls_phonics
+                    '33',  // perf_learner_boys_vocab
+                    '34',  // perf_learner_girls_vocab
+                    '35',  // perf_learner_boys_comprehension
+                    '36',  // perf_learner_girls_comprehension
+                    '37',  // perf_learner_boys_writing
+                    '38'  // perf_learner_girls_writing
+                )
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_perf_learner_report'].values, [3]);
+                })
+                .run();
+        });
+    });
+
+    describe("when the user completes a teacher performance report", function() {
+        it("should fire average sessions to complete metric", function() {
+            return tester
+                .setup.user.addr('097444')
+                .inputs(
+                    {session_event: 'new'},
+                    '1',  // initial_state_district_official
+                    '0001',  // add_emis_perf_teacher_ts_number
+                    '106',  // perf_teacher_ts_number
+                    '2',  // perf_teacher_gender
+                    '30',  // perf_teacher_age
+                    {session_event: 'new'},
+                    '3',  // perf_teacher_academic_level
+                    '1',  // perf_teacher_years_experience
+                    '40',  // perf_teacher_g2_pupils_present
+                    '50',  // perf_teacher_g2_pupils_registered
+                    '8',  // perf_teacher_classroom_environment_score
+                    '7',  // perf_teacher_t_l_materials
+                    '90',  // perf_teacher_pupils_books_number
+                    '6',  // perf_teacher_pupils_materials_score
+                    '14',  // perf_teacher_reading_lesson
+                    '17',  // perf_teacher_pupil_engagement_score
+                    '16',  // perf_teacher_attitudes_and_beliefs
+                    '3',  // perf_teacher_training_subtotal
+                    '10',  // perf_teacher_reading_assessment
+                    '9',  // perf_teacher_reading_total
+                    '1',  // perf_teacher_completed
+
+                    // another report
+                    '106',  // perf_teacher_ts_number
+                    '2',  // perf_teacher_gender
+                    '30',  // perf_teacher_age
+                    {session_event: 'new'},
+                    '3',  // perf_teacher_academic_level
+                    '1',  // perf_teacher_years_experience
+                    {session_event: 'new'},
+                    '40',  // perf_teacher_g2_pupils_present
+                    '50',  // perf_teacher_g2_pupils_registered
+                    '8',  // perf_teacher_classroom_environment_score
+                    {session_event: 'new'},
+                    '7',  // perf_teacher_t_l_materials
+                    '90',  // perf_teacher_pupils_books_number
+                    '6',  // perf_teacher_pupils_materials_score
+                    '14',  // perf_teacher_reading_lesson
+                    '17',  // perf_teacher_pupil_engagement_score
+                    '16',  // perf_teacher_attitudes_and_beliefs
+                    '3',  // perf_teacher_training_subtotal
+                    '10',  // perf_teacher_reading_assessment
+                    '9'  // perf_teacher_reading_total
+                )
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_perf_teacher_report'].values, [2, 4]);
                 })
                 .run();
         });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -2947,6 +2947,27 @@ describe("when a registered user logs on", function() {
                     });
                 });
 
+                describe("if the number validates (equals)", function() {
+                    it.only("should ask for boys below minimum results", function() {
+                        return tester
+                            .setup.user.addr('097555')
+                            .inputs(
+                                'start',
+                                '2',  // initial_state_head_teacher
+                                '10', // perf_learner_boys_total
+                                '5',  // perf_learner_boys_outstanding
+                                '4',  // perf_learner_boys_desirable
+                                '1'  // perf_learner_boys_minimum
+                            )
+                            .check.interaction({
+                                state: 'perf_learner_boys_below_minimum',
+                                reply:
+                                    "In total, how many boys achieved between 0 and 7 out of 20?"
+                            })
+                            .run();
+                    });
+                });
+
                 // test for numeric value
                 describe("if the number does not validate", function() {
                     it("should ask for boys minimum results again", function() {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5378,6 +5378,7 @@ describe.only("test metric firing in various places", function() {
                     assert.deepEqual(metrics['sum.reg_emis.exits'].values, [1]);
                     assert.deepEqual(metrics['sum.reg_emis_validates.exits'].values, [1]);
                     assert.deepEqual(metrics['sum.reg_school_name.exits'].values, [1]);
+                    assert.equal(metrics['sum.reg_first_name.exits'], undefined);
                 })
                 .run();
         });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5180,8 +5180,8 @@ describe("test metric firing in various places", function() {
                 )
                 .check(function(api) {
                     var metrics = api.metrics.stores.test_metric_store;
-                    assert.deepEqual(metrics['sum.learner_performance_reports.ussd'].values, [1]);
-                    assert.deepEqual(metrics['sum.learner_performance_reports.total'].values, [1]);
+                    assert.deepEqual(metrics['sum.learner_performance_reports.ussd'].values, [1, 2]);
+                    assert.deepEqual(metrics['sum.learner_performance_reports.total'].values, [1, 2]);
                 })
                 .run();
         });

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5092,7 +5092,7 @@ describe("when a registered user logs on", function() {
 // METRICS
 // -------
 
-describe("test metric firing in various places", function() {
+describe.only("test metric firing in various places", function() {
 
     describe("when a registered user logs on", function() {
         it("should increase the number of sessions metrics", function() {
@@ -5146,6 +5146,91 @@ describe("test metric firing in various places", function() {
                     var metrics = api.metrics.stores.test_metric_store;
                     assert.deepEqual(metrics['sum.head_teacher_registrations.ussd'].values, [1]);
                     assert.deepEqual(metrics['sum.head_teacher_registrations.total'].values, [1]);
+                })
+                .run();
+        });
+
+        it("should fire average sessions to register metrics", function() {
+            return tester
+                .setup.user.addr('097123')
+                .inputs(
+                    'start',
+                    '1',  // initial_state
+                    '0001',  // reg_emis
+                    '1',  // reg_emis_validates
+                    'School One',  //reg_school_name
+                    'Jack',  // reg_first_name
+                    'Black',  // reg_surname
+                    '11091980',  // reg_date_of_birth
+                    '2',  // reg_gender
+                    '50',  // reg_school_boys
+                    '51',  // reg_school_girls
+                    '5',  // reg_school_classrooms
+                    '5',  // reg_school_teachers
+                    '2',  // reg_school_teachers_g1
+                    '2',  // reg_school_teachers_g2
+                    '10',  // reg_school_students_g2_boys
+                    '11',  // reg_school_students_g2_girls
+                    '2',  // reg_zonal_head
+                    'Jim Carey'  // reg_zonal_head_name
+                )
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_reg_headteacher'].values, [1]);
+                })
+                .run();
+        });
+
+        it("should fire average sessions to register metrics", function() {
+            return tester
+                .setup.user.addr('097123')
+                .inputs(
+                    'start',
+                    '1',  // initial_state
+                    '0001',  // reg_emis
+                    '1',  // reg_emis_validates
+                    'School One',  //reg_school_name
+                    'Jack',  // reg_first_name
+                    'Black',  // reg_surname
+                    '11091980',  // reg_date_of_birth
+                    {session_event: 'new'},
+                    '2',  // reg_gender
+                    '50',  // reg_school_boys
+                    '51',  // reg_school_girls
+                    '5',  // reg_school_classrooms
+                    '5',  // reg_school_teachers
+                    '2',  // reg_school_teachers_g1
+                    '2',  // reg_school_teachers_g2
+                    '10',  // reg_school_students_g2_boys
+                    '11',  // reg_school_students_g2_girls
+                    '1'  // reg_zonal_head
+                )
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_reg_ht_zonal_head'].values, [2]);
+                })
+                .run();
+        });
+    });
+
+    describe("when a user registers as a district official", function() {
+        it("should fire average sessions to register metrics", function() {
+            return tester
+                .setup.user.addr('097123')
+                .inputs(
+                    'start',
+                    '2',
+                    {session_event: 'new'},
+                    '9',
+                    '2',
+                    'Michael',
+                    {session_event: 'new'},
+                    'Sherwin',
+                    '123454321',
+                    '27111980')
+                .check(function(api) {
+                    var metrics = api.metrics.stores.test_metric_store;
+                    assert.deepEqual(metrics['avg.sessions_reg_district_admin'].values, [3]);
                 })
                 .run();
         });

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1000,5 +1000,57 @@ module.exports = function() {
     },
 
 
+    // province metrics
+    // ----------------
+
+        // looks up a school via emis to get province
+    {
+        "request": {
+            "method": "GET",
+            "headers": {
+                'Content-Type': ['application/json']
+            },
+            "url": "http://qa/api/v1/school?emis=45"
+        },
+        "response": {
+            "code": 200,
+            "data": {
+                "meta": {
+                    "limit": 1000,
+                    "next": null,
+                    "offset": 0,
+                    "previous": null,
+                     "total_count": 1
+                },
+                "objects": [
+                    {
+                        "emis": 45,
+                        "id": 1,
+                        "name": "test_school 1",
+                        "resource_uri": "/api/v1/school/1/",
+                        "zone": {
+                            "district": {
+                                "id": 1,
+                                "name": "test_district 1",
+                                "province": {
+                                    "id": 1,
+                                    "name": "test_province",
+                                    "resource_uri": "/api/v1/province/1/"
+                                },
+                                "resource_uri": "/api/v1/district/1/"
+                            },
+                            "id": 1,
+                            "name": "test_zone 1",
+                            "resource_uri": "/api/v1/zone/1/"
+                        }
+                    }
+                ]
+            }
+        }
+    },
+
+
+
+
     ];
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1049,6 +1049,50 @@ module.exports = function() {
         }
     },
 
+    {
+        "request": {
+            "method": "GET",
+            "headers": {
+                'Content-Type': ['application/json']
+            },
+            "url": "http://qa/api/v1/school?emis=0001"
+        },
+        "response": {
+            "code": 200,
+            "data": {
+                "meta": {
+                    "limit": 1000,
+                    "next": null,
+                    "offset": 0,
+                    "previous": null,
+                     "total_count": 1
+                },
+                "objects": [
+                    {
+                        "emis": 1,
+                        "id": 1,
+                        "name": "test_school 1",
+                        "resource_uri": "/api/v1/school/1/",
+                        "zone": {
+                            "district": {
+                                "id": 1,
+                                "name": "test_district 1",
+                                "province": {
+                                    "id": 1,
+                                    "name": "test_province",
+                                    "resource_uri": "/api/v1/province/1/"
+                                },
+                                "resource_uri": "/api/v1/district/1/"
+                            },
+                            "id": 1,
+                            "name": "test_zone 1",
+                            "resource_uri": "/api/v1/zone/1/"
+                        }
+                    }
+                ]
+            }
+        }
+    },
 
 
 


### PR DESCRIPTION
- [x] Activate commented out metrics (self.im.setMaxListeners(x) in self.init)
- [x] Total registered EMIS numbers . django
- [x] Total registered EMIS numbers . total
- [x] Total registered EMIS numbers . ussd
- [x] Average number of USSD sessions per user
- [x] Number of USSD sessions per province
- [x] Average USSD sessions per user needed to complete Registration (wait for helper improvement)
- [x] Handle duplicate metric fires with Django hooks (possibly stop firing .totals in js and fire a decr for .django)
- [x] Fire two metrics on learner performance complete for boys and girls (like django)

<!---
@huboard:{"order":127.0,"milestone_order":127,"custom_state":""}
-->
